### PR TITLE
pullzone: get: rename CacheControlPublicMaxAgeOverride

### DIFF
--- a/pullzone_get.go
+++ b/pullzone_get.go
@@ -53,24 +53,25 @@ const (
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_index2 https://docs.bunny.net/reference/pullzonepublic_index
 type PullZone struct {
-	ID                                    *int64      `json:"Id,omitempty"`
-	AWSSigningEnabled                     *bool       `json:"AWSSigningEnabled,omitempty"`
-	AWSSigningKey                         *string     `json:"AWSSigningKey,omitempty"`
-	AWSSigningRegionName                  *string     `json:"AWSSigningRegionName,omitempty"`
-	AWSSigningSecret                      *string     `json:"AWSSigningSecret,omitempty"`
-	AccessControlOriginHeaderExtensions   []string    `json:"AccessControlOriginHeaderExtensions,omitempty"`
-	AddCanonicalHeader                    *bool       `json:"AddCanonicalHeader,omitempty"`
-	AddHostHeader                         *bool       `json:"AddHostHeader,omitempty"`
-	AllowedReferrers                      []string    `json:"AllowedReferrers,omitempty"`
-	BlockPostRequests                     *bool       `json:"BlockPostRequests,omitempty"`
-	BlockRootPathAccess                   *bool       `json:"BlockRootPathAccess,omitempty"`
-	BlockedCountries                      []string    `json:"BlockedCountries,omitempty"`
-	BlockedIPs                            []string    `json:"BlockedIps,omitempty"`
-	BlockedReferrers                      []string    `json:"BlockedReferrers,omitempty"`
-	BudgetRedirectedCountries             []string    `json:"BudgetRedirectedCountries,omitempty"`
-	BurstSize                             *int32      `json:"BurstSize,omitempty"`
-	CacheControlMaxAgeOverride            *int64      `json:"CacheControlMaxAgeOverride,omitempty"`
-	CacheControlPublicMaxAgeOverride      *int64      `json:"CacheControlPublicMaxAgeOverride,omitempty"`
+	ID                                  *int64   `json:"Id,omitempty"`
+	AWSSigningEnabled                   *bool    `json:"AWSSigningEnabled,omitempty"`
+	AWSSigningKey                       *string  `json:"AWSSigningKey,omitempty"`
+	AWSSigningRegionName                *string  `json:"AWSSigningRegionName,omitempty"`
+	AWSSigningSecret                    *string  `json:"AWSSigningSecret,omitempty"`
+	AccessControlOriginHeaderExtensions []string `json:"AccessControlOriginHeaderExtensions,omitempty"`
+	AddCanonicalHeader                  *bool    `json:"AddCanonicalHeader,omitempty"`
+	AddHostHeader                       *bool    `json:"AddHostHeader,omitempty"`
+	AllowedReferrers                    []string `json:"AllowedReferrers,omitempty"`
+	BlockPostRequests                   *bool    `json:"BlockPostRequests,omitempty"`
+	BlockRootPathAccess                 *bool    `json:"BlockRootPathAccess,omitempty"`
+	BlockedCountries                    []string `json:"BlockedCountries,omitempty"`
+	BlockedIPs                          []string `json:"BlockedIps,omitempty"`
+	BlockedReferrers                    []string `json:"BlockedReferrers,omitempty"`
+	BudgetRedirectedCountries           []string `json:"BudgetRedirectedCountries,omitempty"`
+	BurstSize                           *int32   `json:"BurstSize,omitempty"`
+	CacheControlMaxAgeOverride          *int64   `json:"CacheControlMaxAgeOverride,omitempty"`
+	// CacheControlBrowserMaxAgeOverride is called CacheControlPublicMaxAgeOverride in the API.
+	CacheControlBrowserMaxAgeOverride     *int64      `json:"CacheControlPublicMaxAgeOverride,omitempty"`
 	CnameDomain                           *string     `json:"CnameDomain,omitempty"`
 	ConnectionLimitPerIPCount             *int32      `json:"ConnectionLimitPerIPCount,omitempty"`
 	DNSRecordID                           *int64      `json:"DnsRecordId,omitempty"`


### PR DESCRIPTION
The CacheControlPublicMaxAgeOverride field in the Get API and the
CacheControlBrowserMaxAgeOverride in the Update API refer to the same setting
but have different names.
This is confusing for the user.

Use the same names for the settings in both struct to prevent confusions.
CacheControlBrowserMaxAgeOverride is used as name because in the admin-panel the
setting is called "Browser Cache Expiration Time".