### PR TITLE
client: fix: non-2xx response with empty body caused parsing error

### DIFF
--- a/client.go
+++ b/client.go
@@ -252,6 +252,10 @@ func checkResp(req *http.Request, resp *http.Response) error {
 			return &httpErr
 		}
 
+		if len(httpErr.RespBody) == 0 {
+			return &httpErr
+		}
+
 		var apiErr APIError
 
 		if err := json.Unmarshal(httpErr.RespBody, &apiErr); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,28 @@
+package bunny
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRespWithEmptyUnsuccessfulResp(t *testing.T) {
+	req, err := http.NewRequest("get", "http://test.de", nil)
+	require.NoError(t, err)
+
+	resp := http.Response{
+		StatusCode: 400,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	err = checkResp(req, &resp)
+	require.Error(t, err)
+	require.IsType(t, &HTTPError{}, err)
+
+	httpErr := err.(*HTTPError)
+	assert.Empty(t, httpErr.Errors)
+}


### PR DESCRIPTION
When the client received an non 2xx response with an empty http-response body,
the returned HTTPError.Errors slice contained an
"could not parse body as APIError: unexpected end of JSON input" error.

This was misleading, the body was empty, there was nothing to parse.

This error was returned by json.Unmarshal because an empty buffer was passed to
it.
Check if the buffer is empty before calling json.Unmarshal() when processing
non-successful responses.