### PR TITLE
verify content-type when parsing http-response body

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -21,6 +22,11 @@ const (
 	AccessKeyHeaderKey = "AccessKey"
 	// DefaultUserAgent is the default value of the sent HTTP User-Agent header.
 	DefaultUserAgent = "bunny-go"
+)
+
+const (
+	hdrContentTypeName = "content-type"
+	contentTypeJSON    = "application/json"
 )
 
 // Logf is a log function signature.
@@ -193,29 +199,26 @@ func (c *Client) sendRequest(ctx context.Context, req *http.Request, result inte
 
 	defer resp.Body.Close() //nolint: errcheck
 
-	if err := checkResp(req, resp); err != nil {
+	if err := c.checkResp(req, resp); err != nil {
 		return err
 	}
 
-	buf, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return &HTTPError{
-			RequestURL: req.URL.String(),
-			StatusCode: resp.StatusCode,
-			Errors:     []error{fmt.Errorf("reading response body failed: %w", err)},
-		}
+	return c.unmarshalHTTPJSONBody(resp, req.URL.String(), result)
+}
+
+func ensureJSONContentType(hdr http.Header) error {
+	val := hdr.Get(hdrContentTypeName)
+	if val == "" {
+		return fmt.Errorf("%s header is missing or empty", hdrContentTypeName)
 	}
 
-	if result != nil {
-		err = json.Unmarshal(buf, result)
-		if err != nil {
-			return &HTTPError{
-				RequestURL: req.URL.String(),
-				StatusCode: resp.StatusCode,
-				RespBody:   buf,
-				Errors:     []error{fmt.Errorf("decoding response body into json failed: %w", err)},
-			}
-		}
+	contentType, _, err := mime.ParseMediaType(val)
+	if err != nil {
+		return fmt.Errorf("could not parse %s header value: %w", hdrContentTypeName, err)
+	}
+
+	if contentType != contentTypeJSON {
+		return fmt.Errorf("expected %s to be %q, got: %q", hdrContentTypeName, contentTypeJSON, contentType)
 	}
 
 	return nil
@@ -223,7 +226,7 @@ func (c *Client) sendRequest(ctx context.Context, req *http.Request, result inte
 
 // checkResp checks if the resp indicates that the request was successful.
 // If it wasn't an error is returned.
-func checkResp(req *http.Request, resp *http.Response) error {
+func (c *Client) checkResp(req *http.Request, resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
@@ -242,34 +245,97 @@ func checkResp(req *http.Request, resp *http.Response) error {
 		}
 
 	default:
-		var err error
-
 		httpErr := HTTPError{
 			RequestURL: req.URL.String(),
 			StatusCode: resp.StatusCode,
 		}
 
-		httpErr.RespBody, err = io.ReadAll(resp.Body)
-		if err != nil {
-			httpErr.Errors = append(httpErr.Errors, fmt.Errorf("reading response body failed: %w", err))
-
-			return &httpErr
-		}
-
-		if len(httpErr.RespBody) == 0 {
-			return &httpErr
-		}
-
-		var apiErr APIError
-
-		if err := json.Unmarshal(httpErr.RespBody, &apiErr); err != nil {
-			httpErr.Errors = append(httpErr.Errors, fmt.Errorf("could not parse body as APIError: %w", err))
-			return &httpErr
-		}
-
-		apiErr.HTTPError = httpErr
-		return &apiErr
+		return c.parseHTTPRespErrBody(resp, &httpErr)
 	}
+}
+
+// parseHTTPRespErrBody processes the body of an http.Response with an non 2xx
+// status code.
+// If the response body is empty, baseErr is returned.
+// If the body could no be parsed because of an error, the occurred errors are
+// added to baseErr and baseErr is returned.
+// If the body contains json data it is parsed and an APIError is returned.
+func (c *Client) parseHTTPRespErrBody(resp *http.Response, baseErr *HTTPError) error {
+	var err error
+
+	baseErr.RespBody, err = io.ReadAll(resp.Body)
+	if err != nil {
+		baseErr.Errors = append(baseErr.Errors, fmt.Errorf("reading response body failed: %w", err))
+		return baseErr
+	}
+
+	if len(baseErr.RespBody) == 0 {
+		return baseErr
+	}
+
+	err = ensureJSONContentType(resp.Header)
+	if err != nil {
+		baseErr.Errors = append(baseErr.Errors, fmt.Errorf("processing response failed: %w", err))
+		return baseErr
+	}
+
+	var apiErr APIError
+	if err := json.Unmarshal(baseErr.RespBody, &apiErr); err != nil {
+		baseErr.Errors = append(baseErr.Errors, fmt.Errorf("could not parse body as APIError: %w", err))
+		return baseErr
+	}
+
+	apiErr.HTTPError = *baseErr
+	return &apiErr
+}
+
+func (c *Client) unmarshalHTTPJSONBody(resp *http.Response, reqURL string, result interface{}) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &HTTPError{
+			RequestURL: reqURL,
+			StatusCode: resp.StatusCode,
+			Errors:     []error{fmt.Errorf("reading response body failed: %w", err)},
+		}
+	}
+
+	if len(body) == 0 {
+		if result != nil {
+			return &HTTPError{
+				RequestURL: reqURL,
+				StatusCode: resp.StatusCode,
+				Errors:     []error{fmt.Errorf("response has no body, expected a json %T response bod", result)},
+			}
+		}
+
+		return nil
+	}
+
+	if result == nil {
+		c.logf("http-response contains body but none was expected")
+		return nil
+	}
+
+	err = ensureJSONContentType(resp.Header)
+	if err != nil {
+		return &HTTPError{
+			RequestURL: reqURL,
+			RespBody:   body,
+			StatusCode: resp.StatusCode,
+			Errors:     []error{fmt.Errorf("processing response failed: %w", err)},
+		}
+	}
+
+	if err := json.Unmarshal(body, result); err != nil {
+		return &HTTPError{
+			RequestURL: reqURL,
+			RespBody:   body,
+			StatusCode: resp.StatusCode,
+			Errors:     []error{fmt.Errorf("could not parse body as %T: %w", result, err)},
+		}
+	}
+
+	return nil
 }
 
 func (c *Client) logRequest(req *http.Request) {

--- a/client.go
+++ b/client.go
@@ -96,11 +96,11 @@ func (c *Client) newRequest(method, urlStr string, body io.Reader) (*http.Reques
 	}
 
 	req.Header.Set(AccessKeyHeaderKey, c.apiKey)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", contentTypeJSON)
 	req.Header.Set("User-Agent", c.userAgent)
 
 	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(hdrContentTypeName, contentTypeJSON)
 	}
 
 	return req, nil

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,8 @@
 package bunny
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -19,10 +21,164 @@ func TestCheckRespWithEmptyUnsuccessfulResp(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader("")),
 	}
 
-	err = checkResp(req, &resp)
+	clt := NewClient("")
+
+	err = clt.checkResp(req, &resp)
 	require.Error(t, err)
 	require.IsType(t, &HTTPError{}, err)
 
 	httpErr := err.(*HTTPError)
 	assert.Empty(t, httpErr.Errors)
+}
+
+func TestCheckRespWithJSONBody(t *testing.T) {
+	apiErr := APIError{
+		ErrorKey: "err",
+		Field:    "id",
+		Message:  "something br0ke",
+	}
+
+	buf, err := json.Marshal(&apiErr)
+	require.NoError(t, err)
+
+	const reqURL = "http://test.de"
+	req, err := http.NewRequest("get", reqURL, nil)
+	require.NoError(t, err)
+
+	hdr := http.Header{}
+	hdr.Add("content-type", "application/json; charset=utf-8")
+
+	resp := http.Response{
+		Header:     hdr,
+		StatusCode: 400,
+		Body:       io.NopCloser(bytes.NewReader(buf)),
+	}
+
+	clt := NewClient("")
+
+	err = clt.checkResp(req, &resp)
+	require.Error(t, err)
+	require.IsType(t, &APIError{}, err, "error: "+err.Error())
+
+	retAPIErr := err.(*APIError)
+	assert.Equal(t, apiErr.ErrorKey, retAPIErr.ErrorKey, "unexpected errorKey value")
+	assert.Equal(t, apiErr.Field, retAPIErr.Field, "unexpected field value")
+	assert.Equal(t, apiErr.Message, retAPIErr.Message, "unexpected message value")
+
+	assert.Equal(t, reqURL, retAPIErr.RequestURL, "unexpected RequestURL")
+	assert.Equal(t, resp.StatusCode, retAPIErr.StatusCode, "unexpected status code")
+	assert.Equal(t, buf, retAPIErr.RespBody)
+}
+
+func TestCheckRespWithJSONBodyAndMissingContentType(t *testing.T) {
+	buf, err := json.Marshal(&APIError{Message: "something br0ke"})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("get", "", nil)
+	require.NoError(t, err)
+
+	resp := http.Response{
+		StatusCode: 400,
+		Body:       io.NopCloser(bytes.NewReader(buf)),
+	}
+
+	clt := NewClient("")
+
+	err = clt.checkResp(req, &resp)
+	require.Error(t, err)
+	require.IsType(t, &HTTPError{}, err, "error: "+err.Error())
+
+	retErr := err.(*HTTPError)
+	assert.Equal(t, buf, retErr.RespBody)
+
+	assert.EqualError(t, retErr.Errors[0], "processing response failed: content-type header is missing or empty")
+}
+
+func TestUnmarshalHTTPJSONBody(t *testing.T) {
+	hostnameval := "hello"
+	msgIn := Hostname{
+		Value: &hostnameval,
+	}
+	buf, err := json.Marshal(&msgIn)
+	require.NoError(t, err)
+
+	hdr := http.Header{}
+	hdr.Add("content-type", "application/json; charset=utf-8")
+	resp := http.Response{
+		Body:   io.NopCloser(bytes.NewReader(buf)),
+		Header: hdr,
+	}
+
+	clt := NewClient("")
+
+	var msgOut Hostname
+
+	err = clt.unmarshalHTTPJSONBody(&resp, "", &msgOut)
+	require.NoError(t, err)
+
+	require.NotNil(t, msgOut.Value)
+	require.Equal(t, *msgIn.Value, *msgOut.Value)
+
+}
+
+func TestUnmarshalHTTPJSONBodyWithMissingContentType(t *testing.T) {
+	msgIn := Hostname{}
+	buf, err := json.Marshal(&msgIn)
+	require.NoError(t, err)
+
+	code := 200
+	resp := http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(bytes.NewReader(buf)),
+	}
+
+	clt := NewClient("")
+
+	var msgOut Hostname
+
+	url := "http://test.de"
+	err = clt.unmarshalHTTPJSONBody(&resp, url, &msgOut)
+	require.Error(t, err)
+
+	require.IsType(t, err, &HTTPError{})
+
+	httpErr := err.(*HTTPError)
+	assert.Equal(t, httpErr.RequestURL, url)
+	assert.Equal(t, httpErr.StatusCode, code)
+	assert.Len(t, httpErr.Errors, 1)
+	assert.EqualError(t, httpErr.Errors[0], "processing response failed: content-type header is missing or empty")
+	assert.Equal(t, buf, httpErr.RespBody)
+}
+
+func TestUnmarshalHTTPJSONBodyWithWrongContentType(t *testing.T) {
+	msgIn := Hostname{}
+	buf, err := json.Marshal(&msgIn)
+	require.NoError(t, err)
+
+	hdr := http.Header{}
+	hdr.Add("content-type", "application/binary")
+
+	code := 200
+	resp := http.Response{
+		StatusCode: code,
+		Header:     hdr,
+		Body:       io.NopCloser(bytes.NewReader(buf)),
+	}
+
+	clt := NewClient("")
+
+	var msgOut Hostname
+
+	url := "http://test.de"
+	err = clt.unmarshalHTTPJSONBody(&resp, url, &msgOut)
+	require.Error(t, err)
+
+	require.IsType(t, err, &HTTPError{})
+
+	httpErr := err.(*HTTPError)
+	assert.Equal(t, httpErr.RequestURL, url)
+	assert.Equal(t, httpErr.StatusCode, code)
+	assert.Equal(t, buf, httpErr.RespBody)
+	assert.Len(t, httpErr.Errors, 1)
+	assert.EqualError(t, httpErr.Errors[0], "processing response failed: expected content-type to be \"application/json\", got: \"application/binary\"")
 }

--- a/errors.go
+++ b/errors.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 )
 
-// HTTPError is returned by the Client when the API returned a reply with an
-// unsuccessful status code and the body does not contain a JSON APIError.
+// HTTPError is returned by the Client when an unsuccessful HTTP response was
+// returned or a response could not be processed.
+// If the body of an unsuccessful HTTP response contains an APIError in the
+// body, APIError is returned by the Client instead.
 type HTTPError struct {
 	// RequestURL is the address to which the request was sent that caused the error.
 	RequestURL string


### PR DESCRIPTION
```
client: use contentTypeJSON and hdrContentTypeName constants

Use the newly introduced constants wherever possible

-------------------------------------------------------------------------------
errors: correct HTTPError go documentation

HTTPError is also returned when processing the body of an successful http
response failed, correct the go doc.

-------------------------------------------------------------------------------
client: verify content-type header before parsing response bodies

The client now verifies the content-header of received http-responses.
Before The content-type header was ignored and non-empty bodies were always
parsed as JSON.

Verifying the content-type header allows to return more specific error message
when a response body is not as expected.
```