### PR TITLE
pullzone: add support for Set Force SSL endpoint

### DIFF
--- a/pullzone_set_force_ssl.go
+++ b/pullzone_set_force_ssl.go
@@ -1,0 +1,26 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// SetForceSSLOptions represents the message is to the the Set Force SSL Endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_setforcessl
+type SetForceSSLOptions struct {
+	Hostname *string `json:"Hostname,omitempty"`
+	ForceSSL *bool   `json:"ForceSSL,omitempty"`
+}
+
+// SetForceSSL enables or disables the force SSL option for a hostname of a Pull Zone.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_setforcessl
+func (s *PullZoneService) SetForceSSL(ctx context.Context, pullzoneID int64, opts *SetForceSSLOptions) error {
+	req, err := s.client.newPostRequest(fmt.Sprintf("pullzone/%d/setForceSSL", pullzoneID), opts)
+	if err != nil {
+		return err
+	}
+
+	return s.client.sendRequest(ctx, req, nil)
+}

--- a/pullzone_set_force_ssl_test.go
+++ b/pullzone_set_force_ssl_test.go
@@ -1,0 +1,79 @@
+//go:build integrationtest
+// +build integrationtest
+
+package bunny_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	bunny "github.com/simplesurance/bunny-go"
+)
+
+func TestSetForceSSL(t *testing.T) {
+	ctx := context.Background()
+	clt := newClient(t)
+
+	pzAddopts := bunny.PullZoneAddOptions{
+		Name:      randomPullZoneName(),
+		OriginURL: "http://bunny.net",
+	}
+
+	pz := createPullZone(t, clt, &pzAddopts)
+
+	hostname := "testhostname-" + uuid.New().String() + ".bunny.net"
+	err := clt.PullZone.AddCustomHostname(ctx, *pz.ID, &bunny.AddCustomHostnameOptions{Hostname: &hostname})
+	require.NoError(t, err, "add hostname to pull zone failed")
+
+	trueVal := true
+	err = clt.PullZone.SetForceSSL(ctx, *pz.ID, &bunny.SetForceSSLOptions{
+		Hostname: &hostname,
+		ForceSSL: &trueVal,
+	})
+	require.NoError(t, err, "enabling force ssl failed")
+
+	pz, err = clt.PullZone.Get(ctx, *pz.ID)
+	require.NoError(t, err, "retrieving pull zone failed")
+	assertHostnameForceSSLValue(t, pz.Hostnames, hostname, true)
+
+	falseVal := false
+	err = clt.PullZone.SetForceSSL(ctx, *pz.ID, &bunny.SetForceSSLOptions{
+		Hostname: &hostname,
+		ForceSSL: &falseVal,
+	})
+	require.NoError(t, err, "enabling force ssl failed")
+
+	pz, err = clt.PullZone.Get(ctx, *pz.ID)
+	require.NoError(t, err, "retrieving pull zone failed")
+	assertHostnameForceSSLValue(t, pz.Hostnames, hostname, false)
+
+}
+
+func assertHostnameForceSSLValue(t *testing.T, hostnames []*bunny.Hostname, hostname string, expectedForceSSLVal bool) {
+	t.Helper()
+
+	for _, elem := range hostnames {
+		if elem.Value == nil {
+			t.Errorf("hostname entry has nil Value field")
+			continue
+		}
+
+		if *elem.Value == hostname {
+			if elem.ForceSSL == nil {
+				t.Errorf("hostname entry has nil ForceSSL field")
+				return
+			}
+			if *elem.ForceSSL != expectedForceSSLVal {
+				t.Errorf("expected %v ForceSSL value, got %v, for hostname %q", expectedForceSSLVal, *elem.ForceSSL, hostname)
+				return
+			}
+
+			return
+		}
+	}
+
+	t.Errorf("hostname %q not found in hostnames slices", hostname)
+}


### PR DESCRIPTION
Add a new method SetForceSSL() to the Pull Zone Service that communicates with
the Set Force SSL API endpoint.