### PR TITLE
pullzone: support remove certificate API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Endpoints](https://docs.bunny.net/reference/bunnynet-api-overview) are supported
     - [ ] Purge Cache
     - [x] Load Free Certificate
     - [x] Add Custom Certificate
-    - [ ] Remove Certificate
+    - [x] Remove Certificate
     - [x] Add Custom Hostname
     - [x] Remove Custom Hostname
     - [x] Set Force SSL

--- a/pullzone_add_custom_hostname.go
+++ b/pullzone_add_custom_hostname.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// AddCustomHostnameOptions  represents the message that is sent to the
+// AddCustomHostnameOptions represents the message that is sent to the
 // Add Custom Hostname API Endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_addhostname

--- a/pullzone_remove_certificate.go
+++ b/pullzone_remove_certificate.go
@@ -1,0 +1,26 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// RemoveCertificateOptions represents the request parameters for the Remove
+// Certificate API Endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_removecertificate
+type RemoveCertificateOptions struct {
+	Hostname *string `json:"Hostname,omitempty"`
+}
+
+// RemoveCertificate represents the Remove Certificate API Endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_removecertificate
+func (s *PullZoneService) RemoveCertificate(ctx context.Context, pullZoneID int64, options *RemoveCertificateOptions) error {
+	req, err := s.client.newDeleteRequest(fmt.Sprintf("/pullzone/%d/removeCertificate", pullZoneID), options)
+	if err != nil {
+		return err
+	}
+
+	return s.client.sendRequest(ctx, req, nil)
+}

--- a/pullzone_remove_custom_hostname.go
+++ b/pullzone_remove_custom_hostname.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// RemoveCustomHostnameOptions  represents the message that is sent to the
+// RemoveCustomHostnameOptions represents the message that is sent to the
 // Remove Custom Hostname API Endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_removehostname


### PR DESCRIPTION
Add a RemoveCertificate() method to the PullZoneService.
It interacts with the API endpoint with the same name.