### PR TITLE
edgerules: add constants for new action and trigger types

### DIFF
--- a/edgerules.go
+++ b/edgerules.go
@@ -1,0 +1,39 @@
+package bunny
+
+// EdgeRuleTrigger represents the values of the Trigger field of an EdgeRule.
+type EdgeRuleTrigger struct {
+	Type                *int     `json:"Type,omitempty"`
+	PatternMatches      []string `json:"PatternMatches,omitempty"`
+	PatternMatchingType *int     `json:"PatternMatchingType,omitempty"`
+	Parameter1          *string  `json:"Parameter1,omitempty"`
+}
+
+// Constants for the ActionType fields of an EdgeRule.
+const (
+	EdgeRuleActionTypeForceSSL int = iota
+	EdgeRuleActionTypeRedirect
+	EdgeRuleActionTypeOriginURL
+	EdgeRuleActionTypeOverrideCacheTime
+	EdgeRuleActionTypeBlockRequest
+	EdgeRuleActionTypeSetResponseHeader
+	EdgeRuleActionTypeSetRequestHeader
+	EdgeRuleActionTypeForceDownload
+	EdgeRuleActionTypeDisableTokenAuthentication
+	EdgeRuleActionTypeEnableTokenAuthentication
+	EdgeRuleActionTypeOverrideCacheTimePublic
+	EdgeRuleActionTypeIgnoreQueryString
+	EdgeRuleActionTypeDisableOptimizer
+	EdgeRuleActionTypeForceCompression
+)
+
+// Constants for the Type field of an EdgeRuleTrigger.
+const (
+	EdgeRuleTriggerTypeURL int = iota
+	EdgeRuleTriggerTypeRequestHeader
+	EdgeRuleTriggerTypeResponseHeader
+	EdgeRuleTriggerTypeURLExtension
+	EdgeRuleTriggerTypeCountryCode
+	EdgeRuleTriggerTypeRemoteIP
+	EdgeRuleTriggerTypeURLQueryString
+	EdgeRuleTriggerTypeRandomChance
+)

--- a/edgerules.go
+++ b/edgerules.go
@@ -24,6 +24,8 @@ const (
 	EdgeRuleActionTypeIgnoreQueryString
 	EdgeRuleActionTypeDisableOptimizer
 	EdgeRuleActionTypeForceCompression
+	EdgeRuleActionTypeSetStatusCode
+	EdgeRuleActionTypeBypassPermaCache
 )
 
 // Constants for the Type field of an EdgeRuleTrigger.

--- a/edgerules.go
+++ b/edgerules.go
@@ -38,4 +38,6 @@ const (
 	EdgeRuleTriggerTypeRemoteIP
 	EdgeRuleTriggerTypeURLQueryString
 	EdgeRuleTriggerTypeRandomChance
+	EdgeRuleTriggerTypeStatusCode
+	EdgeRuleTriggerTypeRequestMethod
 )

--- a/pullzone_get.go
+++ b/pullzone_get.go
@@ -19,36 +19,6 @@ const (
 	MatchingTypeNone
 )
 
-// Constants for the ActionType fields of an EdgeRule.
-const (
-	EdgeRuleActionTypeForceSSL int = iota
-	EdgeRuleActionTypeRedirect
-	EdgeRuleActionTypeOriginURL
-	EdgeRuleActionTypeOverrideCacheTime
-	EdgeRuleActionTypeBlockRequest
-	EdgeRuleActionTypeSetResponseHeader
-	EdgeRuleActionTypeSetRequestHeader
-	EdgeRuleActionTypeForceDownload
-	EdgeRuleActionTypeDisableTokenAuthentication
-	EdgeRuleActionTypeEnableTokenAuthentication
-	EdgeRuleActionTypeOverrideCacheTimePublic
-	EdgeRuleActionTypeIgnoreQueryString
-	EdgeRuleActionTypeDisableOptimizer
-	EdgeRuleActionTypeForceCompression
-)
-
-// Constants for the Type field of an EdgeRuleTrigger.
-const (
-	EdgeRuleTriggerTypeURL int = iota
-	EdgeRuleTriggerTypeRequestHeader
-	EdgeRuleTriggerTypeResponseHeader
-	EdgeRuleTriggerTypeURLExtension
-	EdgeRuleTriggerTypeCountryCode
-	EdgeRuleTriggerTypeRemoteIP
-	EdgeRuleTriggerTypeURLQueryString
-	EdgeRuleTriggerTypeRandomChance
-)
-
 // PullZone represents the response of the the List and Get Pull Zone API endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/pullzonepublic_index2 https://docs.bunny.net/reference/pullzonepublic_index
@@ -187,14 +157,6 @@ type EdgeRule struct {
 	TriggerMatchingType *int               `json:"TriggerMatchingType,omitempty"`
 	Description         *string            `json:"Description,omitempty"`
 	Enabled             *bool              `json:"Enabled,omitempty"`
-}
-
-// EdgeRuleTrigger represents the values of the Trigger field of an EdgeRule.
-type EdgeRuleTrigger struct {
-	Type                *int     `json:"Type,omitempty"`
-	PatternMatches      []string `json:"PatternMatches,omitempty"`
-	PatternMatchingType *int     `json:"PatternMatchingType,omitempty"`
-	Parameter1          *string  `json:"Parameter1,omitempty"`
 }
 
 // Get retrieves the Pull Zone with the given id.


### PR DESCRIPTION
```
edgerules: add constants for new edgerule triggers StatusCode and RequestMethod

Both constants are missing in the API documentation but exist in the web UI.
Their IDs were verified by creating edge rules in the UI and retrieving them via
the API.

-------------------------------------------------------------------------------
edgerules: add constants for new action types SetStatusCode, BypassPermaCache

In the bunny.net admin UI 2 new edge rule action types shown up which are
missing in their API documentation.
The support acknowledged that they have id 14 and 15 and it was also checked via
manual tests.

-------------------------------------------------------------------------------
edgerules: move shared definitions to a edgerules.go file

Move definitions that are used by the pullzone and edgerule endpoints to a
edgerules.go file.
This makes those easier to find then in pullzone_get.go.
```