### PR TITLE
feat(dnszone): add support for bunny.net DNS Zones and DNS Zone Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ Endpoints](https://docs.bunny.net/reference/bunnynet-api-overview) are supported
   - [ ] User
 - [ ] Edge Storage API
 - [ ] Stream API
+- [ ] DNS Zone API
+    - [x] List DNS Zones
+    - [x] Add DNS Zone
+    - [x] Get DNS Zone
+    - [x] Update DNS Zones
+    - [x] Delete DNS Zone
+    - [ ] Export DNS Zone
+    - [ ] Get DNS Query Statistics
+    - [x] Add DNS Record
+    - [x] Update DNS Record
+    - [x] Delete DNS Record
+    - [ ] Recheck DNS Configuration
+    - [ ] Dismiss DNS Configuration Notice
+    - [ ] Import DNS Records
 
 ## Example
 

--- a/client.go
+++ b/client.go
@@ -46,6 +46,7 @@ type Client struct {
 
 	PullZone    *PullZoneService
 	StorageZone *StorageZoneService
+	DNSZone     *DNSZoneService
 }
 
 var discardLogF = func(string, ...interface{}) {}
@@ -67,6 +68,7 @@ func NewClient(APIKey string, opts ...Option) *Client {
 
 	clt.PullZone = &PullZoneService{client: &clt}
 	clt.StorageZone = &StorageZoneService{client: &clt}
+	clt.DNSZone = &DNSZoneService{client: &clt}
 
 	for _, opt := range opts {
 		opt(&clt)
@@ -167,6 +169,17 @@ func (c *Client) newDeleteRequest(urlStr string, body interface{}) (*http.Reques
 	}
 
 	return c.newRequest(http.MethodDelete, urlStr, buf)
+}
+
+// newPutRequest creates a bunny.NET API PUT request.
+// If body is not nil, it is encoded as JSON and sent as a HTTP-Body.
+func (c *Client) newPutRequest(urlStr string, body interface{}) (*http.Request, error) {
+	buf, err := toJSON(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.newRequest(http.MethodPut, urlStr, buf)
 }
 
 // sendRequest sends a http Request to the bunny API.

--- a/dnszone.go
+++ b/dnszone.go
@@ -1,0 +1,8 @@
+package bunny
+
+// DNSZoneService communicates with the /dnszone API endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_index
+type DNSZoneService struct {
+	client *Client
+}

--- a/dnszone_add.go
+++ b/dnszone_add.go
@@ -1,0 +1,38 @@
+package bunny
+
+import "context"
+
+// DNSZoneAddOptions are the request parameters for the Get DNS Zone API endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_add
+type DNSZoneAddOptions struct {
+	ID int64 `json:"Id,omitempty"`
+
+	Domain                        string      `json:"Domain,omitempty"`
+	Records                       []DNSRecord `json:"Records,omitempty"`
+	DateModified                  string      `json:"DateModified,omitempty"` // should be time
+	DateCreated                   string      `json:"DateCreated,omitempty"`  // should be time
+	NameserversDetected           bool        `json:"NameserversDetected,omitempty"`
+	CustomNameserversEnabled      bool        `json:"CustomNameserversEnabled,omitempty"`
+	Nameserver1                   string      `json:"Nameserver1,omitempty"`
+	Nameserver2                   string      `json:"Nameserver2,omitempty"`
+	SoaEmail                      string      `json:"SoaEmail,omitempty"`
+	NameserversNextCheck          string      `json:"NameserversNextCheck,omitempty"` // should be time
+	LoggingEnabled                bool        `json:"LoggingEnabled,omitempty"`
+	LoggingIPAnonymizationEnabled bool        `json:"LoggingIPAnonymizationEnabled,omitempty"`
+	LogAnonymizationType          int         `json:"LogAnonymizationType,omitempty"`
+}
+
+// Add creates a new DNS Zone.
+// opts and the non-optional parameters in the struct must be specified for a successful request.
+// On success the created DNSZone is returned.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_add
+func (s *DNSZoneService) Add(ctx context.Context, opts *DNSZoneAddOptions) (*DNSZone, error) {
+	return resourcePostWithResponse[DNSZone](
+		ctx,
+		s.client,
+		"/dnszone",
+		opts,
+	)
+}

--- a/dnszone_add.go
+++ b/dnszone_add.go
@@ -2,33 +2,12 @@ package bunny
 
 import "context"
 
-// DNSZoneAddOptions are the request parameters for the Get DNS Zone API endpoint.
-//
-// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_add
-type DNSZoneAddOptions struct {
-	ID int64 `json:"Id,omitempty"`
-
-	Domain                        string      `json:"Domain,omitempty"`
-	Records                       []DNSRecord `json:"Records,omitempty"`
-	DateModified                  string      `json:"DateModified,omitempty"` // should be time
-	DateCreated                   string      `json:"DateCreated,omitempty"`  // should be time
-	NameserversDetected           bool        `json:"NameserversDetected,omitempty"`
-	CustomNameserversEnabled      bool        `json:"CustomNameserversEnabled,omitempty"`
-	Nameserver1                   string      `json:"Nameserver1,omitempty"`
-	Nameserver2                   string      `json:"Nameserver2,omitempty"`
-	SoaEmail                      string      `json:"SoaEmail,omitempty"`
-	NameserversNextCheck          string      `json:"NameserversNextCheck,omitempty"` // should be time
-	LoggingEnabled                bool        `json:"LoggingEnabled,omitempty"`
-	LoggingIPAnonymizationEnabled bool        `json:"LoggingIPAnonymizationEnabled,omitempty"`
-	LogAnonymizationType          int         `json:"LogAnonymizationType,omitempty"`
-}
-
 // Add creates a new DNS Zone.
 // opts and the non-optional parameters in the struct must be specified for a successful request.
 // On success the created DNSZone is returned.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_add
-func (s *DNSZoneService) Add(ctx context.Context, opts *DNSZoneAddOptions) (*DNSZone, error) {
+func (s *DNSZoneService) Add(ctx context.Context, opts *DNSZone) (*DNSZone, error) {
 	return resourcePostWithResponse[DNSZone](
 		ctx,
 		s.client,

--- a/dnszone_add_dns_record.go
+++ b/dnszone_add_dns_record.go
@@ -5,30 +5,30 @@ import (
 	"fmt"
 )
 
-// AddDNSRecord represents the message that is sent to the
+// AddOrUpdateDNSRecordOptions represents the message that is sent to the
 // Add DNS Record API Endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_addrecord
 type AddOrUpdateDNSRecordOptions struct {
-	ID                     int64                   `json:"Id,omitempty"`
-	Type                   int                     `json:"Type"`
-	Ttl                    int32                   `json:"Ttl,omitempty"`
-	Value                  string                  `json:"Value,omitempty"`
-	Name                   string                  `json:"Name,omitempty"`
-	Weight                 int32                   `json:"Weight,omitempty"`
-	Priority               int32                   `json:"Priority,omitempty"`
-	Flags                  int                     `json:"Flags,omitempty"`
-	Tag                    string                  `json:"Tag,omitempty"`
-	Port                   int32                   `json:"Port,omitempty"`
-	PullZoneId             int64                   `json:"PullZoneId,omitempty"`
-	ScriptId               int64                   `json:"ScriptId,omitempty"`
-	Accelerated            bool                    `json:"Accelerated,omitempty"`
-	MonitorType            int                     `json:"MonitorType,omitempty"`
-	GeolocationLatitude    float64                 `json:"GeolocationLatitude,omitempty"`
-	GeolocationLongitude   float64                 `json:"GeolocationLongitude,omitempty"`
-	LatencyZone            string                  `json:"LatencyZone,omitempty"`
-	SmartRoutingType       int                     `json:"SmartRoutingType,omitempty"`
-	Disabled               bool                    `json:"Disabled,omitempty"`
+	ID                     *int64                  `json:"Id,omitempty"`
+	Type                   *int                    `json:"Type,omitempty"`
+	TTL                    *int32                  `json:"Ttl,omitempty"`
+	Value                  *string                 `json:"Value,omitempty"`
+	Name                   *string                 `json:"Name,omitempty"`
+	Weight                 *int32                  `json:"Weight,omitempty"`
+	Priority               *int32                  `json:"Priority,omitempty"`
+	Flags                  *int                    `json:"Flags,omitempty"`
+	Tag                    *string                 `json:"Tag,omitempty"`
+	Port                   *int32                  `json:"Port,omitempty"`
+	PullZoneID             *int64                  `json:"PullZoneId,omitempty"`
+	ScriptID               *int64                  `json:"ScriptId,omitempty"`
+	Accelerated            *bool                   `json:"Accelerated,omitempty"`
+	MonitorType            *int                    `json:"MonitorType,omitempty"`
+	GeolocationLatitude    *float64                `json:"GeolocationLatitude,omitempty"`
+	GeolocationLongitude   *float64                `json:"GeolocationLongitude,omitempty"`
+	LatencyZone            *string                 `json:"LatencyZone,omitempty"`
+	SmartRoutingType       *int                    `json:"SmartRoutingType,omitempty"`
+	Disabled               *bool                   `json:"Disabled,omitempty"`
 	EnvironmentalVariables []EnvironmentalVariable `json:"EnvironmentalVariables,omitempty"`
 }
 

--- a/dnszone_add_dns_record.go
+++ b/dnszone_add_dns_record.go
@@ -1,0 +1,46 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// AddDNSRecord represents the message that is sent to the
+// Add DNS Record API Endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_addrecord
+type AddOrUpdateDNSRecordOptions struct {
+	ID                     int64                   `json:"Id,omitempty"`
+	Type                   int                     `json:"Type"`
+	Ttl                    int32                   `json:"Ttl,omitempty"`
+	Value                  string                  `json:"Value,omitempty"`
+	Name                   string                  `json:"Name,omitempty"`
+	Weight                 int32                   `json:"Weight,omitempty"`
+	Priority               int32                   `json:"Priority,omitempty"`
+	Flags                  int                     `json:"Flags,omitempty"`
+	Tag                    string                  `json:"Tag,omitempty"`
+	Port                   int32                   `json:"Port,omitempty"`
+	PullZoneId             int64                   `json:"PullZoneId,omitempty"`
+	ScriptId               int64                   `json:"ScriptId,omitempty"`
+	Accelerated            bool                    `json:"Accelerated,omitempty"`
+	MonitorType            int                     `json:"MonitorType,omitempty"`
+	GeolocationLatitude    float64                 `json:"GeolocationLatitude,omitempty"`
+	GeolocationLongitude   float64                 `json:"GeolocationLongitude,omitempty"`
+	LatencyZone            string                  `json:"LatencyZone,omitempty"`
+	SmartRoutingType       int                     `json:"SmartRoutingType,omitempty"`
+	Disabled               bool                    `json:"Disabled,omitempty"`
+	EnvironmentalVariables []EnvironmentalVariable `json:"EnvironmentalVariables,omitempty"`
+}
+
+// AddDNSRecord adds a DNS record to the DNS Zone.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_addrecord
+func (s *DNSZoneService) AddDNSRecord(ctx context.Context, dnsZoneID int64, opts *AddOrUpdateDNSRecordOptions) (*DNSRecord, error) {
+	path := fmt.Sprintf("dnszone/%d/records", dnsZoneID)
+	return resourcePutWithResponse[DNSRecord](
+		ctx,
+		s.client,
+		path,
+		opts,
+	)
+}

--- a/dnszone_delete.go
+++ b/dnszone_delete.go
@@ -1,0 +1,14 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// Delete removes the DNS Zone with the given id.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_delete
+func (s *DNSZoneService) Delete(ctx context.Context, id int64) error {
+	path := fmt.Sprintf("dnszone/%d", id)
+	return resourceDelete(ctx, s.client, path, nil)
+}

--- a/dnszone_delete_dns_record.go
+++ b/dnszone_delete_dns_record.go
@@ -1,0 +1,14 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeleteDNSRecord removes a DNS Record of a DNS Zone.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_deleterecord
+func (s *DNSZoneService) DeleteDNSRecord(ctx context.Context, dnsZoneID int64, dnsRecordID int64) error {
+	path := fmt.Sprintf("dnszone/%d/records/%d", dnsZoneID, dnsRecordID)
+	return resourceDelete(ctx, s.client, path, nil)
+}

--- a/dnszone_get.go
+++ b/dnszone_get.go
@@ -24,28 +24,34 @@ const (
 // DNSZone represents the response of the the List and Get DNS Zone API endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_index2 https://docs.bunny.net/reference/dnszonepublic_index
+//
+// Timestamps formatted in YYYY-MM-DDTHH:MM:SS style.
+// Golang time layout: 2006-01-02T15:04:05
 type DNSZone struct {
 	ID *int64 `json:"Id,omitempty"`
 
 	Domain                        *string     `json:"Domain,omitempty"`
 	Records                       []DNSRecord `json:"Records,omitempty"`
-	DateModified                  *string     `json:"DateModified,omitempty"` // should be time
-	DateCreated                   *string     `json:"DateCreated,omitempty"`  // should be time
+	DateModified                  *string     `json:"DateModified,omitempty"` // Timestamp
+	DateCreated                   *string     `json:"DateCreated,omitempty"`  // Timestamp
 	NameserversDetected           *bool       `json:"NameserversDetected,omitempty"`
 	CustomNameserversEnabled      *bool       `json:"CustomNameserversEnabled,omitempty"`
 	Nameserver1                   *string     `json:"Nameserver1,omitempty"`
 	Nameserver2                   *string     `json:"Nameserver2,omitempty"`
 	SoaEmail                      *string     `json:"SoaEmail,omitempty"`
-	NameserversNextCheck          *string     `json:"NameserversNextCheck,omitempty"` // should be time
+	NameserversNextCheck          *string     `json:"NameserversNextCheck,omitempty"` // Timestamp
 	LoggingEnabled                *bool       `json:"LoggingEnabled,omitempty"`
 	LoggingIPAnonymizationEnabled *bool       `json:"LoggingIPAnonymizationEnabled,omitempty"`
 	LogAnonymizationType          *int        `json:"LogAnonymizationType,omitempty"`
 }
 
+// DNSRecord represents individual DNS records for a DNS Zone.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_index2 https://docs.bunny.net/reference/dnszonepublic_index
 type DNSRecord struct {
 	ID                     *int64                  `json:"Id,omitempty"`
 	Type                   *int                    `json:"Type,omitempty"`
-	Ttl                    *int32                  `json:"Ttl,omitempty"`
+	TTL                    *int32                  `json:"Ttl,omitempty"`
 	Value                  *string                 `json:"Value,omitempty"`
 	Name                   *string                 `json:"Name,omitempty"`
 	Weight                 *int32                  `json:"Weight,omitempty"`
@@ -54,7 +60,7 @@ type DNSRecord struct {
 	Flags                  *int                    `json:"Flags,omitempty"`
 	Tag                    *string                 `json:"Tag,omitempty"`
 	Accelerated            *bool                   `json:"Accelerated,omitempty"`
-	AcceleratedPullZoneId  *int64                  `json:"AcceleratedPullZoneId,omitempty"`
+	AcceleratedPullZoneID  *int64                  `json:"AcceleratedPullZoneId,omitempty"`
 	LinkName               *string                 `json:"LinkName,omitempty"`
 	IPGeoLocationInfo      *IPGeoLocationInfo      `json:"IPGeoLocationInfo,omitempty"`
 	MonitorStatus          *int                    `json:"MonitorStatus,omitempty"`
@@ -67,6 +73,7 @@ type DNSRecord struct {
 	Disabled               *bool                   `json:"Disabled,omitempty"`
 }
 
+// IPGeoLocationInfo represents the geolocation data attached to a DNS record.
 type IPGeoLocationInfo struct {
 	CountryCode      *string `json:"CountryCode,omitempty"`
 	Country          *string `json:"Country,omitempty"`
@@ -75,6 +82,7 @@ type IPGeoLocationInfo struct {
 	City             *string `json:"City,omitempty"`
 }
 
+// EnvironmentalVariable represents the environmental variables attached to a DNS record.
 type EnvironmentalVariable struct {
 	Name  *string `json:"Name,omitempty"`
 	Value *string `json:"Value,omitempty"`

--- a/dnszone_get.go
+++ b/dnszone_get.go
@@ -1,0 +1,89 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// Constants for the Type field of a DNS Record
+const (
+	DNSRecordTypeA     int = 0
+	DNSRecordTypeAAAA  int = 1
+	DNSRecordTypeCNAME int = 2
+	DNSRecordTypeTXT   int = 3
+	DNSRecordTypeMX    int = 4
+	DNSRecordTypeRDR   int = 5 // Bunny.NET Redirect custom record
+	DNSRecordTypePZ    int = 7 // Bunny.NET Pull Zone custom record
+	DNSRecordTypeSRV   int = 8
+	DNSRecordTypeCAA   int = 9
+	DNSRecordTypePTR   int = 10
+	DNSRecordTypeSCR   int = 11 // Bunny.NET Script custom record
+	DNSRecordTypeNS    int = 12
+)
+
+// DNSZone represents the response of the the List and Get DNS Zone API endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_index2 https://docs.bunny.net/reference/dnszonepublic_index
+type DNSZone struct {
+	ID *int64 `json:"Id,omitempty"`
+
+	Domain                        *string     `json:"Domain,omitempty"`
+	Records                       []DNSRecord `json:"Records,omitempty"`
+	DateModified                  *string     `json:"DateModified,omitempty"` // should be time
+	DateCreated                   *string     `json:"DateCreated,omitempty"`  // should be time
+	NameserversDetected           *bool       `json:"NameserversDetected,omitempty"`
+	CustomNameserversEnabled      *bool       `json:"CustomNameserversEnabled,omitempty"`
+	Nameserver1                   *string     `json:"Nameserver1,omitempty"`
+	Nameserver2                   *string     `json:"Nameserver2,omitempty"`
+	SoaEmail                      *string     `json:"SoaEmail,omitempty"`
+	NameserversNextCheck          *string     `json:"NameserversNextCheck,omitempty"` // should be time
+	LoggingEnabled                *bool       `json:"LoggingEnabled,omitempty"`
+	LoggingIPAnonymizationEnabled *bool       `json:"LoggingIPAnonymizationEnabled,omitempty"`
+	LogAnonymizationType          *int        `json:"LogAnonymizationType,omitempty"`
+}
+
+type DNSRecord struct {
+	ID                     *int64                  `json:"Id,omitempty"`
+	Type                   *int                    `json:"Type,omitempty"`
+	Ttl                    *int32                  `json:"Ttl,omitempty"`
+	Value                  *string                 `json:"Value,omitempty"`
+	Name                   *string                 `json:"Name,omitempty"`
+	Weight                 *int32                  `json:"Weight,omitempty"`
+	Priority               *int32                  `json:"Priority,omitempty"`
+	Port                   *int32                  `json:"Port,omitempty"`
+	Flags                  *int                    `json:"Flags,omitempty"`
+	Tag                    *string                 `json:"Tag,omitempty"`
+	Accelerated            *bool                   `json:"Accelerated,omitempty"`
+	AcceleratedPullZoneId  *int64                  `json:"AcceleratedPullZoneId,omitempty"`
+	LinkName               *string                 `json:"LinkName,omitempty"`
+	IPGeoLocationInfo      *IPGeoLocationInfo      `json:"IPGeoLocationInfo,omitempty"`
+	MonitorStatus          *int                    `json:"MonitorStatus,omitempty"`
+	MonitorType            *int                    `json:"MonitorType,omitempty"`
+	GeolocationLatitude    *float64                `json:"GeolocationLatitude,omitempty"`
+	GeolocationLongitude   *float64                `json:"GeolocationLongitude,omitempty"`
+	EnvironmentalVariables []EnvironmentalVariable `json:"EnvironmentalVariables,omitempty"`
+	LatencyZone            *string                 `json:"LatencyZone,omitempty"`
+	SmartRoutingType       *int                    `json:"SmartRoutingType,omitempty"`
+	Disabled               *bool                   `json:"Disabled,omitempty"`
+}
+
+type IPGeoLocationInfo struct {
+	CountryCode      *string `json:"CountryCode,omitempty"`
+	Country          *string `json:"Country,omitempty"`
+	ASN              *int64  `json:"ASN,omitempty"`
+	OrganizationName *string `json:"OrganizationName,omitempty"`
+	City             *string `json:"City,omitempty"`
+}
+
+type EnvironmentalVariable struct {
+	Name  *string `json:"Name,omitempty"`
+	Value *string `json:"Value,omitempty"`
+}
+
+// Get retrieves the DNS Zone with the given id.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_index2
+func (s *DNSZoneService) Get(ctx context.Context, id int64) (*DNSZone, error) {
+	path := fmt.Sprintf("dnszone/%d", id)
+	return resourceGet[DNSZone](ctx, s.client, path)
+}

--- a/dnszone_list.go
+++ b/dnszone_list.go
@@ -1,0 +1,20 @@
+package bunny
+
+import "context"
+
+// DNSZones represents the response of the List DNS Zone API endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_index
+type DNSZones PaginationReply[DNSZone]
+
+// List retrieves the DNS Zones.
+// If opts is nil, DefaultPaginationPerPage and DefaultPaginationPage will be used.
+// if opts.Page or or opts.PerPage is < 1, the related DefaultPagination values are used.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_index
+func (s *DNSZoneService) List(
+	ctx context.Context,
+	opts *PaginationOptions,
+) (*DNSZones, error) {
+	return resourceList[DNSZones](ctx, s.client, "/dnszone", opts)
+}

--- a/dnszone_update.go
+++ b/dnszone_update.go
@@ -5,18 +5,18 @@ import (
 	"fmt"
 )
 
-// DNSZoneUpdateOptoins represents the request parameters for the Update DNS
+// DNSZoneUpdateOptions represents the request parameters for the Update DNS
 // Zone API endpoint.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_update
 type DNSZoneUpdateOptions struct {
-	CustomNameserversEnabled      bool   `json:"CustomNameserversEnabled,omitempty"`
-	Nameserver1                   string `json:"Nameserver1,omitempty"`
-	Nameserver2                   string `json:"Nameserver2,omitempty"`
-	SoaEmail                      string `json:"SoaEmail,omitempty"`
-	LoggingEnabled                bool   `json:"LoggingEnabled,omitempty"`
-	LoggingIPAnonymizationEnabled bool   `json:"LoggingIPAnonymizationEnabled,omitempty"`
-	LogAnonymizationType          int    `json:"LogAnonymizationType,omitempty"`
+	CustomNameserversEnabled      *bool   `json:"CustomNameserversEnabled,omitempty"`
+	Nameserver1                   *string `json:"Nameserver1,omitempty"`
+	Nameserver2                   *string `json:"Nameserver2,omitempty"`
+	SoaEmail                      *string `json:"SoaEmail,omitempty"`
+	LoggingEnabled                *bool   `json:"LoggingEnabled,omitempty"`
+	LoggingIPAnonymizationEnabled *bool   `json:"LoggingIPAnonymizationEnabled,omitempty"`
+	LogAnonymizationType          *int    `json:"LogAnonymizationType,omitempty"`
 }
 
 // Update changes the configuration the DNS Zone with the given ID.

--- a/dnszone_update.go
+++ b/dnszone_update.go
@@ -1,0 +1,33 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// DNSZoneUpdateOptoins represents the request parameters for the Update DNS
+// Zone API endpoint.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_update
+type DNSZoneUpdateOptions struct {
+	CustomNameserversEnabled      bool   `json:"CustomNameserversEnabled,omitempty"`
+	Nameserver1                   string `json:"Nameserver1,omitempty"`
+	Nameserver2                   string `json:"Nameserver2,omitempty"`
+	SoaEmail                      string `json:"SoaEmail,omitempty"`
+	LoggingEnabled                bool   `json:"LoggingEnabled,omitempty"`
+	LoggingIPAnonymizationEnabled bool   `json:"LoggingIPAnonymizationEnabled,omitempty"`
+	LogAnonymizationType          int    `json:"LogAnonymizationType,omitempty"`
+}
+
+// Update changes the configuration the DNS Zone with the given ID.
+// The updated DNS Zone is returned.
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_update
+func (s *DNSZoneService) Update(ctx context.Context, id int64, opts *DNSZoneUpdateOptions) (*DNSZone, error) {
+	path := fmt.Sprintf("dnszone/%d", id)
+	return resourcePostWithResponse[DNSZone](
+		ctx,
+		s.client,
+		path,
+		opts,
+	)
+}

--- a/dnszone_update_dns_record.go
+++ b/dnszone_update_dns_record.go
@@ -1,0 +1,14 @@
+package bunny
+
+import (
+	"context"
+	"fmt"
+)
+
+// UpdateDNSRecord updates a DNS record in the DNS Zone.
+//
+// Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_updaterecord
+func (s *DNSZoneService) UpdateDNSRecord(ctx context.Context, dnsZoneID int64, dnsRecordId int64, opts *AddOrUpdateDNSRecordOptions) error {
+	path := fmt.Sprintf("dnszone/%d/records/%d", dnsZoneID, dnsRecordId)
+	return resourcePost(ctx, s.client, path, opts)
+}

--- a/dnszone_update_dns_record.go
+++ b/dnszone_update_dns_record.go
@@ -8,7 +8,7 @@ import (
 // UpdateDNSRecord updates a DNS record in the DNS Zone.
 //
 // Bunny.net API docs: https://docs.bunny.net/reference/dnszonepublic_updaterecord
-func (s *DNSZoneService) UpdateDNSRecord(ctx context.Context, dnsZoneID int64, dnsRecordId int64, opts *AddOrUpdateDNSRecordOptions) error {
-	path := fmt.Sprintf("dnszone/%d/records/%d", dnsZoneID, dnsRecordId)
+func (s *DNSZoneService) UpdateDNSRecord(ctx context.Context, dnsZoneID int64, dnsRecordID int64, opts *AddOrUpdateDNSRecordOptions) error {
+	path := fmt.Sprintf("dnszone/%d/records/%d", dnsZoneID, dnsRecordID)
 	return resourcePost(ctx, s.client, path, opts)
 }

--- a/resource_put.go
+++ b/resource_put.go
@@ -1,0 +1,37 @@
+package bunny
+
+import "context"
+
+func resourcePutWithResponse[Resp any](
+	ctx context.Context,
+	client *Client,
+	path string,
+	requestBody any,
+) (*Resp, error) {
+	var res Resp
+
+	req, err := client.newPutRequest(path, requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.sendRequest(ctx, req, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+func resourcePut(
+	ctx context.Context,
+	client *Client,
+	path string,
+	requestBody any,
+) error {
+	req, err := client.newPutRequest(path, requestBody)
+	if err != nil {
+		return err
+	}
+
+	return client.sendRequest(ctx, req, nil)
+}

--- a/resource_put.go
+++ b/resource_put.go
@@ -21,17 +21,3 @@ func resourcePutWithResponse[Resp any](
 
 	return &res, nil
 }
-
-func resourcePut(
-	ctx context.Context,
-	client *Client,
-	path string,
-	requestBody any,
-) error {
-	req, err := client.newPutRequest(path, requestBody)
-	if err != nil {
-		return err
-	}
-
-	return client.sendRequest(ctx, req, nil)
-}


### PR DESCRIPTION
This PR adds nearly full support for Bunny's new DNS functionality. Specifics are in the updated README, but broadly: DNS Zone management (add/delete/list/update/get) and DNS Record management (add/delete/update) are covered, but non-core features (e.g. record importing/exporting, getting statistics) are currently not covered — this seems in line with how `bunny-go` has handled other Bunny API components, such as Pull Zones.

This PR also adds support for `PUT` requests, as these are required by the Bunny DNS API.