### PR TITLE
tests: fix: AddCustomHostname() calls fail

### DIFF
--- a/pullzone_hostname_test.go
+++ b/pullzone_hostname_test.go
@@ -23,7 +23,7 @@ func TestPullZoneAddRemoveHostname(t *testing.T) {
 
 	pz := createPullZone(t, clt, &pzAddopts)
 
-	hostname := "testhostname-" + uuid.New().String() + ".bunny.net"
+	hostname := "testhostname-" + uuid.New().String() + ".bunnytftest.de"
 	err := clt.PullZone.AddCustomHostname(context.Background(), *pz.ID, &bunny.AddCustomHostnameOptions{Hostname: &hostname})
 	require.NoError(t, err, "add hostname to pull zone failed")
 

--- a/pullzone_set_force_ssl_test.go
+++ b/pullzone_set_force_ssl_test.go
@@ -24,7 +24,7 @@ func TestSetForceSSL(t *testing.T) {
 
 	pz := createPullZone(t, clt, &pzAddopts)
 
-	hostname := "testhostname-" + uuid.New().String() + ".bunny.net"
+	hostname := "testhostname-" + uuid.New().String() + ".bunnytftest.de"
 	err := clt.PullZone.AddCustomHostname(ctx, *pz.ID, &bunny.AddCustomHostnameOptions{Hostname: &hostname})
 	require.NoError(t, err, "add hostname to pull zone failed")
 


### PR DESCRIPTION
adding bogus hostnames like
testhostname-4f13e6d5-2f94-4e87-b129-69cf9d1fb161.bunny.net, to a pull-zone in testcases started to fail with the error:
	Bad Request (400), pullzone.hostname_invalid, The domain
	testhostname-4f13e6d5-2f94-4e87-b129-69cf9d1fb161.bunny.net cannot be
	registered.

When using a different domain with .de as TLD, the operations succeed. Change the testcases to use bunnyftest.de as domain instead.