### PR TITLE
videolib: minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Endpoints](https://docs.bunny.net/reference/bunnynet-api-overview) are supported
 
 - [ ] bunny.net API
   - [ ] Billing
-  - [ ] Stream Video Library
   - [ ] [Pull Zone](https://docs.bunny.net/reference/pullzonepublic_index)
     - [x] Add
     - [x] Update
@@ -114,8 +113,8 @@ See [client_example_test.go](client_example_test.go)
 
 To run the integration test a Bunny.Net API Key is required. \
 The integration tests will create, modify and delete resources on your Bunny.Net
-account. Therefore it is **strongly recommended** to use a Bunny.Net account that is
-**not** used in production environments. \
+account. Therefore it is **strongly recommended** to use a Bunny.Net account
+that is **not** used in production environments. \
 Bunny.Net might charge your account for certain API operations. \
 The integrationtest should remove all resources that they create. It can happen
 that cleaning up the resources fails and the account will contain test

--- a/resource_get.go
+++ b/resource_get.go
@@ -6,11 +6,11 @@ func resourceGet[Resp any](
 	ctx context.Context,
 	client *Client,
 	path string,
-	opts interface{},
+	params interface{},
 ) (*Resp, error) {
 	var res Resp
 
-	req, err := client.newGetRequest(path, opts)
+	req, err := client.newGetRequest(path, params)
 	if err != nil {
 		return nil, err
 	}

--- a/videolibrary_get.go
+++ b/videolibrary_get.go
@@ -64,7 +64,7 @@ type VideoLibrary struct {
 
 // VideoLibraryGetOpts represents optional query parameters available when Getting or Listing Video Libraries
 type VideoLibraryGetOpts struct {
-	IncludeAccessKey bool `url:"includeAccessKey,omitempty"`
+	IncludeAccessKey bool `url:"includeAccessKey"`
 }
 
 // Get retrieves the Video Library with the given id.

--- a/videolibrary_list.go
+++ b/videolibrary_list.go
@@ -23,20 +23,13 @@ func (s *VideoLibraryService) List(
 	ctx context.Context,
 	opts *VideoLibraryListOpts,
 ) (*VideoLibraries, error) {
-	return videLibraryList[VideoLibraries](ctx, s.client, "/videolibrary", opts)
-}
+	const path = "/videolibrary"
+	var res VideoLibraries
 
-// NOTE: this is an override of resourceList strictly for the purpose of
-// providing the extra query param options in VideoLibraryGetOpts. In the future
-// hopefully it can be removed for a better solution. See the following discussion:
-// https://github.com/simplesurance/bunny-go/pull/27#discussion_r1021270152
-func videLibraryList[Resp any](
-	ctx context.Context,
-	client *Client,
-	path string,
-	opts *VideoLibraryListOpts,
-) (*Resp, error) {
-	var res Resp
+	// NOTE: The resourceList function is not used for the purpose of
+	// providing the extra query param options in VideoLibraryGetOpts. In the future
+	// hopefully it can be removed for a better solution. See the following discussion:
+	// https://github.com/simplesurance/bunny-go/pull/27#discussion_r1021270152
 
 	// Ensure that opts.Page is >=1, if it isn't bunny.net will send a
 	// different response JSON object, that contains only a single Object,
@@ -53,12 +46,12 @@ func videLibraryList[Resp any](
 		opts.ensureConstraints()
 	}
 
-	req, err := client.newGetRequest(path, opts)
+	req, err := s.client.newGetRequest(path, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := client.sendRequest(ctx, req, &res); err != nil {
+	if err := s.client.sendRequest(ctx, req, &res); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
```
readme: remove duplicate "Stream Video Library" feature list entry

-------------------------------------------------------------------------------
videolibrary/list: simplify the implementation

Merge the videLibraryList() function into the VideoLibraryService.List() method.

-------------------------------------------------------------------------------
resourceGet: rename opts parameter to params

The parameter specifies the URL parameter, name it "params" instead of "opts".

-------------------------------------------------------------------------------
videolibrary/get: always pass includeAccessKey parameter

If the IncludeAccessKey parameter was false, it would not be passed as request
parameter to the get API endpoint. If the behavior on bunny.net would change
regarding if a missing includeAccessKey parameter means true or false, the
behavior of the bunny-go lib would change too.

By removing omitempty we guarantee consistent behavior, independent of a change
on bunny.net side regarding the default for a missing includeAccessKey
parameter.

-------------------------------------------------------------------------------
```